### PR TITLE
#20 Implement resolvers for type relation fields

### DIFF
--- a/src/resolvers/Book.ts
+++ b/src/resolvers/Book.ts
@@ -1,15 +1,19 @@
 import { BookResolvers } from '../types/graphqlgen';
+import { Publisher, User, Rating } from '../types/types';
 
 export const Book: BookResolvers.Type = {
   ...BookResolvers.defaultResolvers,
 
-  publishers: (parent, args, ctx) => {
-    throw new Error('Resolver not implemented');
+  publishers: async ({ id }, args, { prisma }): Promise<Publisher[]> => {
+    const publishers: Publisher[] = await prisma.book({ id }).publishers();
+    return publishers;
   },
-  authors: (parent, args, ctx) => {
-    throw new Error('Resolver not implemented');
+  authors: async ({ id }, args, { prisma }): Promise<User[]> => {
+    const authors: User[] = await prisma.book({ id }).authors();
+    return authors;
   },
-  ratings: (parent, args, ctx) => {
-    throw new Error('Resolver not implemented');
+  ratings: async ({ id }, args, { prisma }): Promise<Rating[]> => {
+    const ratings: Rating[] = prisma.book({ id }).ratings();
+    return ratings;
   },
 };

--- a/src/resolvers/Mutation/index.ts
+++ b/src/resolvers/Mutation/index.ts
@@ -1,18 +1,21 @@
 import AuthMutation from './AuthMutation';
 import { IContext } from '../../types/IContext';
 import { MutationResolvers } from '../../types/graphqlgen';
+import { GraphQLResolveInfo } from 'graphql';
 
 const mutation: MutationResolvers.Type = {
   signup: (
     parent: undefined,
     args: MutationResolvers.ArgsSignup,
     context: IContext,
-  ) => AuthMutation.signup(parent, args, context),
+    info: GraphQLResolveInfo,
+  ) => AuthMutation.signup(parent, args, context, info),
   login: (
     parent: undefined,
     args: MutationResolvers.ArgsLogin,
     context: IContext,
-  ) => AuthMutation.login(parent, args, context),
+    info: GraphQLResolveInfo,
+  ) => AuthMutation.login(parent, args, context, info),
 };
 
 export default mutation;

--- a/src/resolvers/Publisher.ts
+++ b/src/resolvers/Publisher.ts
@@ -1,9 +1,11 @@
 import { PublisherResolvers } from '../types/graphqlgen';
+import { Book } from '../types/types';
 
 export const Publisher: PublisherResolvers.Type = {
   ...PublisherResolvers.defaultResolvers,
 
-  publication: (parent, args, ctx) => {
-    throw new Error('Resolver not implemented');
+  publication: async ({ id }, args, { prisma }): Promise<Book[]> => {
+    const publication: Book[] = await prisma.publisher({ id }).publication();
+    return publication;
   },
 };

--- a/src/resolvers/Rating.ts
+++ b/src/resolvers/Rating.ts
@@ -1,12 +1,15 @@
 import { RatingResolvers } from '../types/graphqlgen';
+import { User, Book } from '../types/types';
 
 export const Rating: RatingResolvers.Type = {
   ...RatingResolvers.defaultResolvers,
 
-  rater: (parent, args, ctx) => {
-    throw new Error('Resolver not implemented');
+  rater: async ({ id }, args, { prisma }): Promise<User> => {
+    const rater: User = await prisma.rating({ id }).rater();
+    return rater;
   },
-  book: (parent, args, ctx) => {
-    throw new Error('Resolver not implemented');
+  book: async ({ id }, args, { prisma }): Promise<Book> => {
+    const book: Book = await prisma.rating({ id }).book();
+    return book;
   },
 };

--- a/src/resolvers/Review.ts
+++ b/src/resolvers/Review.ts
@@ -1,12 +1,15 @@
 import { ReviewResolvers } from '../types/graphqlgen';
+import { User, Book } from '../types/types';
 
 export const Review: ReviewResolvers.Type = {
   ...ReviewResolvers.defaultResolvers,
 
-  reviewer: (parent, args, ctx) => {
-    throw new Error('Resolver not implemented');
+  reviewer: async ({ id }, args, { prisma }): Promise<User> => {
+    const reviewer: User = await prisma.review({ id }).reviewer();
+    return reviewer;
   },
-  book: (parent, args, ctx) => {
-    throw new Error('Resolver not implemented');
+  book: async ({ id }, args, { prisma }): Promise<Book> => {
+    const book: Book = await prisma.review({ id }).book();
+    return book;
   },
 };

--- a/src/resolvers/User.ts
+++ b/src/resolvers/User.ts
@@ -1,12 +1,15 @@
 import { UserResolvers } from '../types/graphqlgen';
+import { Book, Review } from '../types/types';
 
 export const User: UserResolvers.Type = {
   ...UserResolvers.defaultResolvers,
 
-  books: (parent, args, ctx) => {
-    throw new Error('Resolver not implemented');
+  books: async ({ id }, args, { prisma }): Promise<Book[]> => {
+    const books: Book[] = await prisma.user({ id }).books();
+    return books;
   },
-  reviews: (parent, args, ctx) => {
-    throw new Error('Resolver not implemented');
+  reviews: async ({ id }, args, { prisma }): Promise<Review[]> => {
+    const reviews: Review[] = await prisma.user({ id }).reviews();
+    return reviews;
   },
 };

--- a/src/resolvers/index.ts
+++ b/src/resolvers/index.ts
@@ -1,10 +1,20 @@
 import Query from './Query';
 import Mutation from './Mutation';
 import { Resolvers } from '../types/graphqlgen';
+import { User } from './User';
+import { Book } from './Book';
+import { Publisher } from './Publisher';
+import { Review } from './Review';
+import { Rating } from './Rating';
 
 const resolvers: Partial<Resolvers> = {
   Query,
   Mutation,
+  User,
+  Book,
+  Publisher,
+  Review,
+  Rating,
 };
 
 export default resolvers;


### PR DESCRIPTION
#### What does this PR do?
- This PR implements resolvers for type relation fields
#### Description of Task to be completed?
- Add resolver function to the relation fields on the types
#### How should this be manually tested?
- Set up the repo locally
- Run `npm run dev`
- Create a `createPublisher` mutation on `localhost:PORT/playground`
- Observe the results
#### Any background context you want to provide?
- Currently, relation fields on the types don't have resolvers and Prisma doesn't return relations by default.
#### What are the relevant pivotal tracker stories?
- [#20](https://github.com/chukwuemekachm/GraphQL-API/issues/20)
#### Screenshots (if appropriate)
 - N/A
#### Questions:
- N/A