### PR TITLE
#21 Implements create publisher resolver

### DIFF
--- a/src/resolvers/Mutation/PublisherMutation.ts
+++ b/src/resolvers/Mutation/PublisherMutation.ts
@@ -1,0 +1,59 @@
+import { IContext } from '../../types/IContext';
+import FormatedError from '../../errors/FormatedError';
+import { PublisherValidator } from '../../validators/PublisherValidator';
+import validateRequest, {
+  IValidationErrors,
+  validationMessage,
+} from '../../validators';
+import { Publisher } from '../../prisma/generated/prisma-client';
+import { MutationResolvers } from '../../types/graphqlgen';
+
+class PublisherMutation {
+  /**
+   * @description Creates a new publisher on the platform
+   * Returning the newly created publisher
+   *
+   * @param {object} parent The previous GraphQL object
+   * @param {object} args The request payload
+   * @param {object} context The request context
+   *
+   * @returns {object}
+   */
+  public static createPublisher: MutationResolvers.CreatePublisherResolver = async (
+    parent: undefined,
+    { publisher: publisherInput }: any,
+    { prisma }: IContext,
+  ): Promise<Publisher> => {
+    try {
+      const { name, about, address } = publisherInput;
+      const errors: IValidationErrors | boolean = await validateRequest(
+        PublisherValidator,
+        publisherInput,
+      );
+      if (errors) {
+        throw new FormatedError(validationMessage, errors);
+      }
+
+      const publisher = await prisma.$exists.publisher({
+        OR: [{ name_contains: name }, { about_contains: about }],
+      });
+      if (!publisher) {
+        const newPublisher = await prisma.createPublisher({
+          name,
+          about,
+          address,
+        });
+        return newPublisher;
+      }
+
+      throw new FormatedError('Publisher with similar information exist', {
+        name: ['A publisher with similar name exists'],
+        about: ['A publisher with similar details exists'],
+      });
+    } catch (err) {
+      throw err;
+    }
+  };
+}
+
+export default PublisherMutation;

--- a/src/resolvers/Mutation/index.ts
+++ b/src/resolvers/Mutation/index.ts
@@ -2,6 +2,7 @@ import AuthMutation from './AuthMutation';
 import { IContext } from '../../types/IContext';
 import { MutationResolvers } from '../../types/graphqlgen';
 import { GraphQLResolveInfo } from 'graphql';
+import PublisherMutation from './PublisherMutation';
 
 const mutation: MutationResolvers.Type = {
   signup: (
@@ -16,6 +17,12 @@ const mutation: MutationResolvers.Type = {
     context: IContext,
     info: GraphQLResolveInfo,
   ) => AuthMutation.login(parent, args, context, info),
+  createPublisher: (
+    parent: undefined,
+    args: any,
+    context: IContext,
+    info: GraphQLResolveInfo,
+  ) => PublisherMutation.createPublisher(parent, args, context, info),
 };
 
 export default mutation;

--- a/src/resolvers/index.ts
+++ b/src/resolvers/index.ts
@@ -7,7 +7,7 @@ import { Publisher } from './Publisher';
 import { Review } from './Review';
 import { Rating } from './Rating';
 
-const resolvers: Partial<Resolvers> = {
+const resolvers: Resolvers = {
   Query,
   Mutation,
   User,

--- a/src/schema.graphql
+++ b/src/schema.graphql
@@ -7,6 +7,7 @@ type Query {
 type Mutation {
   signup(user: SignupInput): AuthResponse!
   login(user: LoginInput): AuthResponse!
+  createPublisher(publisher: PublisherInput): Publisher!
 }
 
 type AuthResponse {
@@ -24,6 +25,12 @@ input SignupInput {
 input LoginInput {
   email: String!
   password: String!
+}
+
+input PublisherInput {
+  name: String!
+  about: String!
+  address: String!
 }
 
 type Publisher {

--- a/src/types/IAuthMutation.ts
+++ b/src/types/IAuthMutation.ts
@@ -1,13 +1,6 @@
-import { IContext } from './IContext';
-
-export type ResolverFunction = (
-  parent: any,
-  args: any,
-  context: IContext,
-  info?: any,
-) => any;
+import { MutationResolvers } from './graphqlgen';
 
 export abstract class IAuthMutation {
-  static signup: ResolverFunction;
-  static login: ResolverFunction;
+  static signup: MutationResolvers.SignupResolver;
+  static login: MutationResolvers.LoginResolver;
 }

--- a/src/types/IPublisherMutation.ts
+++ b/src/types/IPublisherMutation.ts
@@ -1,0 +1,5 @@
+import { MutationResolvers } from './graphqlgen';
+
+export abstract class IPublisherMutation {
+  static createPublisher: MutationResolvers.CreatePublisherResolver;
+}

--- a/src/types/graphqlgen.ts
+++ b/src/types/graphqlgen.ts
@@ -44,6 +44,11 @@ export namespace MutationResolvers {
     email: string;
     password: string;
   }
+  export interface PublisherInput {
+    name: string;
+    about: string;
+    address: string;
+  }
 
   export interface ArgsSignup {
     user?: SignupInput | null;
@@ -51,6 +56,10 @@ export namespace MutationResolvers {
 
   export interface ArgsLogin {
     user?: LoginInput | null;
+  }
+
+  export interface ArgsCreatePublisher {
+    publisher?: PublisherInput | null;
   }
 
   export type SignupResolver = (
@@ -67,6 +76,13 @@ export namespace MutationResolvers {
     info: GraphQLResolveInfo,
   ) => AuthResponse | Promise<AuthResponse>;
 
+  export type CreatePublisherResolver = (
+    parent: undefined,
+    args: ArgsCreatePublisher,
+    ctx: IContext,
+    info: GraphQLResolveInfo,
+  ) => Publisher | Promise<Publisher>;
+
   export interface Type {
     signup: (
       parent: undefined,
@@ -81,6 +97,13 @@ export namespace MutationResolvers {
       ctx: IContext,
       info: GraphQLResolveInfo,
     ) => AuthResponse | Promise<AuthResponse>;
+
+    createPublisher: (
+      parent: undefined,
+      args: ArgsCreatePublisher,
+      ctx: IContext,
+      info: GraphQLResolveInfo,
+    ) => Publisher | Promise<Publisher>;
   }
 }
 
@@ -693,10 +716,10 @@ export namespace ReviewResolvers {
 export interface Resolvers {
   Query: QueryResolvers.Type;
   Mutation: MutationResolvers.Type;
-  AuthResponse: AuthResponseResolvers.Type;
   User: UserResolvers.Type;
   Book: BookResolvers.Type;
   Publisher: PublisherResolvers.Type;
   Rating: RatingResolvers.Type;
   Review: ReviewResolvers.Type;
+  [key: string]: object;
 }

--- a/src/validators/PublisherValidator.ts
+++ b/src/validators/PublisherValidator.ts
@@ -1,0 +1,27 @@
+import { Length, IsString } from 'class-validator';
+
+interface IPublisherValidatorPayload {
+  name: string;
+  address: string;
+  about: string;
+}
+
+export class PublisherValidator implements IPublisherValidatorPayload {
+  @IsString()
+  @Length(2, 50)
+  name: string;
+
+  @IsString()
+  @Length(2, 50)
+  address: string;
+
+  @IsString()
+  @Length(10, 250)
+  about: string;
+
+  constructor({ name, address, about }: IPublisherValidatorPayload) {
+    this.name = name;
+    this.about = about;
+    this.address = address;
+  }
+}


### PR DESCRIPTION
#### What does this PR do?
- This PR implements the `createPublisher` mutation.
#### Description of Task to be completed?
- Create publisher validator
- Validate publisher inputs
- Check for existence of a publisher with similar details
- Return newly created publisher details
- Update types
#### How should this be manually tested?
- Set up the repo locally.
- Create a `createPublisher` mutation
- Observe the result and behaviours.
#### Any background context you want to provide?
#### What are the relevant Github issues?
- [#21](https://github.com/chukwuemekachm/GraphQL-API/issues/21)
#### Screenshots (if appropriate)

![screenshot 2019-01-25 at 11 14 13 am 2](https://user-images.githubusercontent.com/33798252/51739826-c1c8ff00-2092-11e9-998c-9b3303dc25e5.png)


![screenshot 2019-01-25 at 11 16 03 am 2](https://user-images.githubusercontent.com/33798252/51739827-c2619580-2092-11e9-906f-c377a99a3eb3.png)

#### Questions:
- N/A