### PR TITLE
#25 Implements get authors query resolver

### DIFF
--- a/src/resolvers/Mutation/AuthMutation.ts
+++ b/src/resolvers/Mutation/AuthMutation.ts
@@ -1,6 +1,6 @@
 import * as bcrypt from 'bcryptjs';
 
-import { IAuthMutation } from '../../types/IAuthMutation';
+import { IAuthMutation } from '../../types/mutation/IAuthMutation';
 import { IContext } from '../../types/IContext';
 import { generateToken } from '../../helpers/jwtHelper';
 import validateRequest, {

--- a/src/resolvers/Mutation/PublisherMutation.ts
+++ b/src/resolvers/Mutation/PublisherMutation.ts
@@ -7,7 +7,7 @@ import validateRequest, {
 } from '../../validators';
 import { Publisher } from '../../prisma/generated/prisma-client';
 import { MutationResolvers } from '../../types/graphqlgen';
-import { IPublisherMutation } from '../../types/IPublisherMutation';
+import { IPublisherMutation } from '../../types/mutation/IPublisherMutation';
 
 class PublisherMutation implements IPublisherMutation {
   /**

--- a/src/resolvers/Mutation/UserMutation.ts
+++ b/src/resolvers/Mutation/UserMutation.ts
@@ -1,4 +1,4 @@
-import { IUserMutation } from '../../types/IUserMutation';
+import { IUserMutation } from '../../types/mutation/IUserMutation';
 import { MutationResolvers } from '../../types/graphqlgen';
 import { IContext } from '../../types/IContext';
 import { User } from '../../prisma/generated/prisma-client';

--- a/src/resolvers/Mutation/index.ts
+++ b/src/resolvers/Mutation/index.ts
@@ -20,13 +20,13 @@ const mutation: MutationResolvers.Type = {
   ) => AuthMutation.login(parent, args, context, info),
   createPublisher: (
     parent: undefined,
-    args: any,
+    args: MutationResolvers.ArgsCreatePublisher,
     context: IContext,
     info: GraphQLResolveInfo,
   ) => PublisherMutation.createPublisher(parent, args, context, info),
   createAuthor: (
     parent: undefined,
-    args: any,
+    args: MutationResolvers.ArgsCreateAuthor,
     context: IContext,
     info: GraphQLResolveInfo,
   ) => UserMutation.createAuthor(parent, args, context, info),

--- a/src/resolvers/Query/PublisherQuery.ts
+++ b/src/resolvers/Query/PublisherQuery.ts
@@ -1,7 +1,9 @@
 import { Publisher } from '../../prisma/generated/prisma-client';
 import { IContext } from '../../types/IContext';
+import { QueryResolvers } from '../../types/graphqlgen';
+import { IPublisherQuery } from '../../types/query/IPublisherQuery';
 
-class PublisherQuery {
+class PublisherQuery implements IPublisherQuery {
   /**
    * @description Returns a list of publishers on the platform
    * Returning an ordered, filtered and paginated list of publishers
@@ -12,7 +14,7 @@ class PublisherQuery {
    *
    * @returns {array}
    */
-  public static getPublishers = async (
+  public static getPublishers: QueryResolvers.GetPublishersResolver = async (
     parent: undefined,
     { sort: publisherInput = {} }: any,
     { prisma }: IContext,

--- a/src/resolvers/Query/UserQuery.ts
+++ b/src/resolvers/Query/UserQuery.ts
@@ -1,0 +1,48 @@
+import { User } from '../../prisma/generated/prisma-client';
+import { IContext } from '../../types/IContext';
+import { QueryResolvers } from '../../types/graphqlgen';
+import { IUserQuery } from '../../types/query/IUserQuery';
+
+class UserQuery implements IUserQuery {
+  /**
+   * @description Returns a list of authors on the platform
+   * Returning an ordered, filtered and paginated list of authors
+   *
+   * @param {object} parent The previous GraphQL object
+   * @param {object} args The request payload
+   * @param {object} context The request context
+   *
+   * @returns {object}
+   */
+  public static getAuthors: QueryResolvers.GetAuthorsResolver = async (
+    parent: undefined,
+    { sort: authorInput = {} }: any,
+    { prisma }: IContext,
+  ): Promise<User[]> => {
+    try {
+      const { search, orderBy, offset, limit } = authorInput;
+
+      return prisma.users({
+        where: {
+          AND: [
+            { type: 'AUTHOR' },
+            {
+              OR: [
+                { lastName_contains: search },
+                { firstName_contains: search },
+                { email_contains: search },
+              ],
+            },
+          ],
+        },
+        orderBy,
+        skip: offset,
+        first: limit,
+      });
+    } catch (err) {
+      throw err;
+    }
+  };
+}
+
+export default UserQuery;

--- a/src/resolvers/Query/index.ts
+++ b/src/resolvers/Query/index.ts
@@ -3,15 +3,22 @@ import { GraphQLResolveInfo } from 'graphql';
 import { QueryResolvers } from '../../types/graphqlgen';
 import { IContext } from '../../types/IContext';
 import PublisherQuery from './PublisherQuery';
+import UserQuery from './UserQuery';
 
 const query: QueryResolvers.Type = {
   info: () => 'Welcome to my GraphQL API! 🚀 🚀',
   getPublishers: (
     parent: undefined,
+    args: QueryResolvers.ArgsGetPublishers,
+    context: IContext,
+    info: GraphQLResolveInfo,
+  ) => PublisherQuery.getPublishers(parent, args, context, info),
+  getAuthors: (
+    parent: undefined,
     args: any,
     context: IContext,
     info: GraphQLResolveInfo,
-  ) => PublisherQuery.getPublishers(parent, args, context),
+  ) => UserQuery.getAuthors(parent, args, context, info),
 };
 
 export default query;

--- a/src/schema.graphql
+++ b/src/schema.graphql
@@ -3,6 +3,7 @@ scalar DateTime
 type Query {
   info: String!
   getPublishers(sort: PublisherSearchPaginationOrderInput): [Publisher!]!
+  getAuthors(sort: UserSearchPaginationOrderInput): [User!]!
 }
 
 type Mutation {
@@ -48,11 +49,31 @@ input PublisherSearchPaginationOrderInput {
   limit: Int
 }
 
+input UserSearchPaginationOrderInput {
+  search: String
+  orderBy: UserOrderBy
+  offset: Int
+  limit: Int
+}
+
 enum PublisherOrderBy {
   name_ASC
   name_DESC
   about_ASC
   about_DESC
+  createdAt_ASC
+  createdAt_DESC
+}
+
+enum UserOrderBy {
+  lastName_ASC
+  lastName_DESC
+  firstName_ASC
+  firstName_DESC
+  email_ASC
+  email_DESC
+  id_ASC
+  id_DESC
   createdAt_ASC
   createdAt_DESC
 }

--- a/src/types/graphqlgen.ts
+++ b/src/types/graphqlgen.ts
@@ -18,6 +18,17 @@ export type PublisherOrderBy =
   | 'about_DESC'
   | 'createdAt_ASC'
   | 'createdAt_DESC';
+export type UserOrderBy =
+  | 'lastName_ASC'
+  | 'lastName_DESC'
+  | 'firstName_ASC'
+  | 'firstName_DESC'
+  | 'email_ASC'
+  | 'email_DESC'
+  | 'id_ASC'
+  | 'id_DESC'
+  | 'createdAt_ASC'
+  | 'createdAt_DESC';
 
 export namespace QueryResolvers {
   export const defaultResolvers = {};
@@ -28,9 +39,19 @@ export namespace QueryResolvers {
     offset?: number | null;
     limit?: number | null;
   }
+  export interface UserSearchPaginationOrderInput {
+    search?: string | null;
+    orderBy?: UserOrderBy | null;
+    offset?: number | null;
+    limit?: number | null;
+  }
 
   export interface ArgsGetPublishers {
     sort?: PublisherSearchPaginationOrderInput | null;
+  }
+
+  export interface ArgsGetAuthors {
+    sort?: UserSearchPaginationOrderInput | null;
   }
 
   export type InfoResolver = (
@@ -47,6 +68,13 @@ export namespace QueryResolvers {
     info: GraphQLResolveInfo,
   ) => Publisher[] | Promise<Publisher[]>;
 
+  export type GetAuthorsResolver = (
+    parent: undefined,
+    args: ArgsGetAuthors,
+    ctx: IContext,
+    info: GraphQLResolveInfo,
+  ) => User[] | Promise<User[]>;
+
   export interface Type {
     info: (
       parent: undefined,
@@ -61,6 +89,13 @@ export namespace QueryResolvers {
       ctx: IContext,
       info: GraphQLResolveInfo,
     ) => Publisher[] | Promise<Publisher[]>;
+
+    getAuthors: (
+      parent: undefined,
+      args: ArgsGetAuthors,
+      ctx: IContext,
+      info: GraphQLResolveInfo,
+    ) => User[] | Promise<User[]>;
   }
 }
 

--- a/src/types/mutation/IAuthMutation.ts
+++ b/src/types/mutation/IAuthMutation.ts
@@ -1,4 +1,4 @@
-import { MutationResolvers } from './graphqlgen';
+import { MutationResolvers } from '../graphqlgen';
 
 export abstract class IAuthMutation {
   static signup: MutationResolvers.SignupResolver;

--- a/src/types/mutation/IPublisherMutation.ts
+++ b/src/types/mutation/IPublisherMutation.ts
@@ -1,4 +1,4 @@
-import { MutationResolvers } from './graphqlgen';
+import { MutationResolvers } from '../graphqlgen';
 
 export abstract class IPublisherMutation {
   static createPublisher: MutationResolvers.CreatePublisherResolver;

--- a/src/types/mutation/IUserMutation.ts
+++ b/src/types/mutation/IUserMutation.ts
@@ -1,4 +1,4 @@
-import { MutationResolvers } from './graphqlgen';
+import { MutationResolvers } from '../graphqlgen';
 
 export abstract class IUserMutation {
   static createAuthor: MutationResolvers.CreateAuthorResolver;

--- a/src/types/query/IPublisherQuery.ts
+++ b/src/types/query/IPublisherQuery.ts
@@ -1,0 +1,5 @@
+import { QueryResolvers } from '../graphqlgen';
+
+export abstract class IPublisherQuery {
+  static getPublishers: QueryResolvers.GetPublishersResolver;
+}

--- a/src/types/query/IUserQuery.ts
+++ b/src/types/query/IUserQuery.ts
@@ -1,0 +1,5 @@
+import { QueryResolvers } from '../graphqlgen';
+
+export abstract class IUserQuery {
+  static getAuthors: QueryResolvers.GetPublishersResolver;
+}


### PR DESCRIPTION
#### What does this PR do?
- This PR implements the `getAuthors` query.
#### Description of Task to be completed?
- Add getAuthors query resolver
- Add a new user field to the Prisma data-model
- Update GraphQL schema
- Add new types definition
#### How should this be manually tested?
- Set up the repo locally.
- Create a `getAuthors` query
- Add `search`, `limit`, `orderBy`, and `offset` parameters to sort, paginate, and filter as desired
- Observe the result and behaviours.
#### Any background context you want to provide?
#### What are the relevant Github issues?
- [#25](https://github.com/chukwuemekachm/GraphQL-API/issues/25)
#### Screenshots (if appropriate)


![screenshot 2019-01-26 at 1 33 53 am](https://user-images.githubusercontent.com/33798252/51795239-36f61a80-21e0-11e9-89f8-e31ce848420e.png)


#### Questions:
- N/A