### PR TITLE
#33 Implements create review resolver

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,1 +1,2 @@
 APP_SECRET=<string>
+PRISMA_ENDPOINT=<string>

--- a/src/prisma/generated/prisma-client/index.ts
+++ b/src/prisma/generated/prisma-client/index.ts
@@ -2844,6 +2844,6 @@ export const models: Model[] = [
 export const Prisma = makePrismaClientClass<ClientConstructor<Prisma>>({
   typeDefs,
   models,
-  endpoint: `http://localhost:4466`,
+  endpoint: <string>process.env.PRISMA_ENDPOINT,
 });
 export const prisma = new Prisma();

--- a/src/resolvers/Book.ts
+++ b/src/resolvers/Book.ts
@@ -1,5 +1,6 @@
 import { BookResolvers } from '../types/graphqlgen';
 import { Publisher, User, Rating } from '../types/types';
+import { Review } from '../prisma/generated/prisma-client';
 
 export const Book: BookResolvers.Type = {
   ...BookResolvers.defaultResolvers,
@@ -15,5 +16,9 @@ export const Book: BookResolvers.Type = {
   ratings: async ({ id }, args, { prisma }): Promise<Rating[]> => {
     const ratings: Rating[] = prisma.book({ id }).ratings();
     return ratings;
+  },
+  reviews: async ({ id }, args, { prisma }): Promise<Review[]> => {
+    const reviews: Review[] = prisma.book({ id }).reviews();
+    return reviews;
   },
 };

--- a/src/resolvers/Mutation/ReviewMutation.ts
+++ b/src/resolvers/Mutation/ReviewMutation.ts
@@ -1,0 +1,62 @@
+import { MutationResolvers } from '../../types/graphqlgen';
+import { IContext } from '../../types/IContext';
+import validateRequest, {
+  IValidationErrors,
+  validationMessage,
+} from '../../validators';
+import FormatedError from '../../errors/FormatedError';
+import { Review } from '../../prisma/generated/prisma-client';
+import { IReviewMutation } from '../../types/mutation/IReviewMutation';
+import { ReviewValidator } from '../../validators/ReviewValidation';
+
+class ReviewMutation implements IReviewMutation {
+  /**
+   * @description Creates a new book review on the platform
+   * Returning the newly created review and it's relations
+   *
+   * @param {object} parent The previous GraphQL object
+   * @param {object} args The request payload
+   * @param {object} context The request context
+   *
+   * @returns {object}
+   */
+  public static createReview: MutationResolvers.CreateReviewResolver = async (
+    parent: undefined,
+    { review: reviewInput }: any,
+    { prisma }: IContext,
+  ): Promise<Review> => {
+    try {
+      const { review, reviewer, book } = reviewInput;
+      const errors: IValidationErrors | boolean = await validateRequest(
+        ReviewValidator,
+        reviewInput,
+      );
+      if (errors) {
+        throw new FormatedError(validationMessage, errors);
+      }
+
+      const userExists = await prisma.$exists.user({ id: reviewer });
+      const bookExists = await prisma.$exists.book({ id: book });
+      if (!userExists) {
+        throw new FormatedError(`User with id: ${reviewer} does not exist`, {
+          reviewer: [`User with id: ${reviewer} does not exist`],
+        });
+      }
+      if (!bookExists) {
+        throw new FormatedError(`Book with id: ${book} does not exist`, {
+          book: [`Book with id: ${book} does not exist`],
+        });
+      }
+
+      return prisma.createReview({
+        review,
+        reviewer: { connect: { id: reviewer } },
+        book: { connect: { id: book } },
+      });
+    } catch (err) {
+      throw err;
+    }
+  };
+}
+
+export default ReviewMutation;

--- a/src/resolvers/Mutation/index.ts
+++ b/src/resolvers/Mutation/index.ts
@@ -1,10 +1,12 @@
+import { GraphQLResolveInfo } from 'graphql';
+
 import AuthMutation from './AuthMutation';
 import { IContext } from '../../types/IContext';
 import { MutationResolvers } from '../../types/graphqlgen';
-import { GraphQLResolveInfo } from 'graphql';
 import PublisherMutation from './PublisherMutation';
 import UserMutation from './UserMutation';
 import BookMutation from './BookMutation';
+import ReviewMutation from './ReviewMutation';
 
 const mutation: MutationResolvers.Type = {
   signup: (
@@ -37,6 +39,12 @@ const mutation: MutationResolvers.Type = {
     context: IContext,
     info: GraphQLResolveInfo,
   ) => BookMutation.createBook(parent, args, context, info),
+  createReview: (
+    parent: undefined,
+    args: MutationResolvers.ArgsCreateReview,
+    context: IContext,
+    info: GraphQLResolveInfo,
+  ) => ReviewMutation.createReview(parent, args, context, info),
 };
 
 export default mutation;

--- a/src/resolvers/Query/BookQuery.ts
+++ b/src/resolvers/Query/BookQuery.ts
@@ -25,8 +25,7 @@ class BookQuery implements IBookQuery {
         OR: [
           { title_contains: search },
           { description_contains: search },
-          { isbnNo: search },
-          { publishDateTime: search },
+          { isbnNo_contains: search },
         ],
       };
 

--- a/src/schema.graphql
+++ b/src/schema.graphql
@@ -13,6 +13,7 @@ type Mutation {
   createPublisher(publisher: PublisherInput): Publisher!
   createAuthor(user: AuthorInput!): User!
   createBook(book: BookInput!): Book!
+  createReview(review: ReviewInput!): Review!
 }
 
 type AuthResponse {
@@ -52,6 +53,12 @@ input BookInput {
   publishDateTime: DateTime!
   authors: [String!]!
   isbnNo: String
+}
+
+input ReviewInput {
+  review: String!
+  reviewer: String!
+  book: String!
 }
 
 input PublisherSearchPaginationOrderInput {
@@ -138,6 +145,7 @@ type Book {
   publishDateTime: DateTime!
   authors: [User!]!
   ratings: [Rating!]
+  reviews: [Review!]!
   isbnNo: String
   createdAt: DateTime!
   updatedAt: DateTime!

--- a/src/types/graphqlgen.ts
+++ b/src/types/graphqlgen.ts
@@ -56,7 +56,7 @@ export namespace QueryResolvers {
   }
   export interface BookSearchPaginationOrderInput {
     search?: string | null;
-    orderBy?: Book | null;
+    orderBy?: BookOrderBy | null;
     offset?: number | null;
     limit?: number | null;
   }
@@ -315,6 +315,13 @@ export namespace BookResolvers {
     info: GraphQLResolveInfo,
   ) => Rating[] | null | Promise<Rating[] | null>;
 
+  export type ReviewsResolver = (
+    parent: Book,
+    args: {},
+    ctx: IContext,
+    info: GraphQLResolveInfo,
+  ) => Review[] | Promise<Review[]>;
+
   export type IsbnNoResolver = (
     parent: Book,
     args: {},
@@ -392,6 +399,13 @@ export namespace BookResolvers {
       ctx: IContext,
       info: GraphQLResolveInfo,
     ) => Rating[] | null | Promise<Rating[] | null>;
+
+    reviews: (
+      parent: Book,
+      args: {},
+      ctx: IContext,
+      info: GraphQLResolveInfo,
+    ) => Review[] | Promise<Review[]>;
 
     isbnNo: (
       parent: Book,
@@ -733,6 +747,11 @@ export namespace MutationResolvers {
     authors: string[];
     isbnNo?: string | null;
   }
+  export interface ReviewInput {
+    review: string;
+    reviewer: string;
+    book: string;
+  }
 
   export interface ArgsSignup {
     user?: SignupInput | null;
@@ -752,6 +771,10 @@ export namespace MutationResolvers {
 
   export interface ArgsCreateBook {
     book: BookInput;
+  }
+
+  export interface ArgsCreateReview {
+    review: ReviewInput;
   }
 
   export type SignupResolver = (
@@ -789,6 +812,13 @@ export namespace MutationResolvers {
     info: GraphQLResolveInfo,
   ) => Book | Promise<Book>;
 
+  export type CreateReviewResolver = (
+    parent: undefined,
+    args: ArgsCreateReview,
+    ctx: IContext,
+    info: GraphQLResolveInfo,
+  ) => Review | Promise<Review>;
+
   export interface Type {
     signup: (
       parent: undefined,
@@ -824,6 +854,13 @@ export namespace MutationResolvers {
       ctx: IContext,
       info: GraphQLResolveInfo,
     ) => Book | Promise<Book>;
+
+    createReview: (
+      parent: undefined,
+      args: ArgsCreateReview,
+      ctx: IContext,
+      info: GraphQLResolveInfo,
+    ) => Review | Promise<Review>;
   }
 }
 

--- a/src/types/mutation/IReviewMutation.ts
+++ b/src/types/mutation/IReviewMutation.ts
@@ -1,0 +1,5 @@
+import { MutationResolvers } from '../graphqlgen';
+
+export abstract class IReviewMutation {
+  static createReview: MutationResolvers.CreateReviewResolver;
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -53,3 +53,16 @@ export const checkPublishers = async (publishers: string[], prisma: Prisma) => {
     throw err;
   }
 };
+
+/**
+ * @description Capitalizes the first letter of a string
+ * Returning the capitalized string
+ *
+ * @param {string} word The string to be capitalized
+ *
+ * @returns {string}
+ */
+export const capitalize = (word: string): string => {
+  if (!word[1]) return word.toUpperCase();
+  return `${word[0].toUpperCase()}${word.substring(1)}`;
+};

--- a/src/validators/ReviewValidation.ts
+++ b/src/validators/ReviewValidation.ts
@@ -1,0 +1,30 @@
+import { Length, IsOptional, IsString } from 'class-validator';
+
+interface IReviewValidatorPayload {
+  review: string;
+  reviewer: string;
+  book: string;
+}
+
+export class ReviewValidator implements IReviewValidatorPayload {
+  @IsOptional()
+  @IsString()
+  @Length(5, 250)
+  review: string;
+
+  @IsOptional()
+  @IsString()
+  @Length(5, 250)
+  reviewer: string;
+
+  @IsOptional()
+  @IsString()
+  @Length(5, 250)
+  book: string;
+
+  constructor({ review, reviewer, book }: IReviewValidatorPayload) {
+    this.review = review;
+    this.reviewer = reviewer;
+    this.book = book;
+  }
+}


### PR DESCRIPTION
#### What does this PR do?
- This PR implements the `createReview` mutation.
#### Description of Task to be completed?
- Add Review validator
- Update API schema
- Update type defination
- Create new resolver
- Return created review
#### How should this be manually tested?
- Set up the repo locally.
- Create a `createReview` mutation
- Observe the result and behaviours.
#### Any background context you want to provide?
#### What are the relevant Github issues?
- [#33](https://github.com/chukwuemekachm/GraphQL-API/issues/33)
#### Screenshots (if appropriate)

<img width="1437" alt="screenshot 2019-01-31 at 11 40 29 am" src="https://user-images.githubusercontent.com/33798252/52056394-6ef3b980-2562-11e9-8e8d-1fbe382c6631.png">


<img width="721" alt="screenshot 2019-01-31 at 11 40 02 am" src="https://user-images.githubusercontent.com/33798252/52056395-6ef3b980-2562-11e9-8392-b799bf2076dc.png">


#### Questions:
- N/A