### PR TITLE
#34 Implements get reviews query resolver

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,25 +36,25 @@
     ]
   },
   "dependencies": {
+    "@types/aws-lambda": "^8.10.17",
+    "@types/bcryptjs": "^2.4.2",
+    "@types/dotenv": "^6.1.0",
+    "@types/jsonwebtoken": "^8.3.0",
+    "@types/ws": "^6.0.1",
     "bcryptjs": "^2.4.3",
     "class-validator": "^0.9.1",
     "dotenv": "^6.2.0",
     "graphql-yoga": "^1.16.9",
     "jsonwebtoken": "^8.4.0",
     "merge-graphql-schemas": "^1.5.8",
-    "prisma-client-lib": "^1.24.0"
+    "prisma-client-lib": "^1.24.0",
+    "typescript": "^3.2.2"
   },
   "devDependencies": {
-    "@types/aws-lambda": "^8.10.17",
-    "@types/bcryptjs": "^2.4.2",
-    "@types/dotenv": "^6.1.0",
-    "@types/jsonwebtoken": "^8.3.0",
-    "@types/ws": "^6.0.1",
     "husky": "^1.3.1",
     "lint-staged": "^8.1.0",
     "nodemon": "^1.18.9",
     "prettier": "1.15.3",
-    "ts-node": "^7.0.1",
-    "typescript": "^3.2.2"
+    "ts-node": "^7.0.1"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,7 +22,7 @@ server.start(
   {
     port: PORT || 4000,
     endpoint: '/graphql',
-    playground: process.env.NODE_ENV !== 'production' ? '/playground' : false,
+    playground: '/playground',
     formatError: (error: GraphQLError) => errorFormater(error),
   },
   () => console.log(`Server is running on http://localhost:${PORT} 🚀`),

--- a/src/resolvers/Book.ts
+++ b/src/resolvers/Book.ts
@@ -1,6 +1,10 @@
 import { BookResolvers } from '../types/graphqlgen';
-import { Publisher, User, Rating } from '../types/types';
-import { Review } from '../prisma/generated/prisma-client';
+import {
+  Review,
+  Publisher,
+  User,
+  Rating,
+} from '../prisma/generated/prisma-client';
 
 export const Book: BookResolvers.Type = {
   ...BookResolvers.defaultResolvers,

--- a/src/resolvers/Publisher.ts
+++ b/src/resolvers/Publisher.ts
@@ -1,5 +1,5 @@
 import { PublisherResolvers } from '../types/graphqlgen';
-import { Book } from '../types/types';
+import { Book } from '../prisma/generated/prisma-client';
 
 export const Publisher: PublisherResolvers.Type = {
   ...PublisherResolvers.defaultResolvers,

--- a/src/resolvers/Query/ReviewQuery.ts
+++ b/src/resolvers/Query/ReviewQuery.ts
@@ -1,0 +1,40 @@
+import { IContext } from '../../types/IContext';
+import { QueryResolvers } from '../../types/graphqlgen';
+import { IReviewQuery } from '../../types/query/IReviewQuery';
+import { Review } from '../../prisma/generated/prisma-client';
+
+class ReviewQuery implements IReviewQuery {
+  /**
+   * @description Returns a list of reviews on the platform
+   * Returning an ordered, filtered and paginated list of reviews
+   *
+   * @param {object} parent The previous GraphQL object
+   * @param {object} args The request payload
+   * @param {object} context The request context
+   *
+   * @returns {array}
+   */
+  public static getReviews: QueryResolvers.GetReviewsResolver = async (
+    parent: undefined,
+    { sort: reviewInput = {} }: any,
+    { prisma }: IContext,
+  ): Promise<Review[]> => {
+    try {
+      const { search, orderBy, offset, limit } = reviewInput;
+      const where = {
+        review_contains: search,
+      };
+
+      return prisma.reviews({
+        where,
+        orderBy,
+        skip: offset,
+        first: limit,
+      });
+    } catch (err) {
+      throw err;
+    }
+  };
+}
+
+export default ReviewQuery;

--- a/src/resolvers/Query/index.ts
+++ b/src/resolvers/Query/index.ts
@@ -5,6 +5,7 @@ import { IContext } from '../../types/IContext';
 import PublisherQuery from './PublisherQuery';
 import UserQuery from './UserQuery';
 import BookQuery from './BookQuery';
+import ReviewQuery from './ReviewQuery';
 
 const query: QueryResolvers.Type = {
   info: () => 'Welcome to my GraphQL API! 🚀 🚀',
@@ -26,6 +27,12 @@ const query: QueryResolvers.Type = {
     context: IContext,
     info: GraphQLResolveInfo,
   ) => BookQuery.getBooks(parent, args, context, info),
+  getReviews: (
+    parent: undefined,
+    args: any,
+    context: IContext,
+    info: GraphQLResolveInfo,
+  ) => ReviewQuery.getReviews(parent, args, context, info),
 };
 
 export default query;

--- a/src/resolvers/Rating.ts
+++ b/src/resolvers/Rating.ts
@@ -1,5 +1,5 @@
 import { RatingResolvers } from '../types/graphqlgen';
-import { User, Book } from '../types/types';
+import { User, Book } from '../prisma/generated/prisma-client';
 
 export const Rating: RatingResolvers.Type = {
   ...RatingResolvers.defaultResolvers,

--- a/src/resolvers/Review.ts
+++ b/src/resolvers/Review.ts
@@ -1,5 +1,5 @@
 import { ReviewResolvers } from '../types/graphqlgen';
-import { User, Book } from '../types/types';
+import { User, Book } from '../prisma/generated/prisma-client';
 
 export const Review: ReviewResolvers.Type = {
   ...ReviewResolvers.defaultResolvers,

--- a/src/resolvers/User.ts
+++ b/src/resolvers/User.ts
@@ -1,5 +1,5 @@
 import { UserResolvers } from '../types/graphqlgen';
-import { Book, Review } from '../types/types';
+import { Book, Review } from '../prisma/generated/prisma-client';
 
 export const User: UserResolvers.Type = {
   ...UserResolvers.defaultResolvers,

--- a/src/schema.graphql
+++ b/src/schema.graphql
@@ -5,6 +5,7 @@ type Query {
   getPublishers(sort: PublisherSearchPaginationOrderInput): [Publisher!]!
   getAuthors(sort: UserSearchPaginationOrderInput): [User!]!
   getBooks(sort: BookSearchPaginationOrderInput): [Book!]!
+  getReviews(sort: ReviewSearchPaginationOrderInput): [Review!]!
 }
 
 type Mutation {
@@ -82,6 +83,13 @@ input BookSearchPaginationOrderInput {
   limit: Int
 }
 
+input ReviewSearchPaginationOrderInput {
+  search: String
+  orderBy: ReviewOrderBy
+  offset: Int
+  limit: Int
+}
+
 enum PublisherOrderBy {
   name_ASC
   name_DESC
@@ -111,6 +119,13 @@ enum BookOrderBy {
   description_DESC
   isbnNo_ASC
   isbnNo_DESC
+  createdAt_ASC
+  createdAt_DESC
+}
+
+enum ReviewOrderBy {
+  review_ASC
+  review_DESC
   createdAt_ASC
   createdAt_DESC
 }

--- a/src/types/graphqlgen.ts
+++ b/src/types/graphqlgen.ts
@@ -38,6 +38,11 @@ export type BookOrderBy =
   | 'isbnNo_DESC'
   | 'createdAt_ASC'
   | 'createdAt_DESC';
+export type ReviewOrderBy =
+  | 'review_ASC'
+  | 'review_DESC'
+  | 'createdAt_ASC'
+  | 'createdAt_DESC';
 
 export namespace QueryResolvers {
   export const defaultResolvers = {};
@@ -73,6 +78,10 @@ export namespace QueryResolvers {
     sort?: BookSearchPaginationOrderInput | null;
   }
 
+  export interface ArgsGetReviews {
+    sort?: ReviewOrderBy | null;
+  }
+
   export type InfoResolver = (
     parent: undefined,
     args: {},
@@ -100,6 +109,13 @@ export namespace QueryResolvers {
     ctx: IContext,
     info: GraphQLResolveInfo,
   ) => Book[] | Promise<Book[]>;
+
+  export type GetReviewsResolver = (
+    parent: undefined,
+    args: ArgsGetReviews,
+    ctx: IContext,
+    info: GraphQLResolveInfo,
+  ) => Review[] | Promise<Review[]>;
 
   export interface Type {
     info: (
@@ -129,6 +145,13 @@ export namespace QueryResolvers {
       ctx: IContext,
       info: GraphQLResolveInfo,
     ) => Book[] | Promise<Book[]>;
+
+    getReviews: (
+      parent: undefined,
+      args: ArgsGetReviews,
+      ctx: IContext,
+      info: GraphQLResolveInfo,
+    ) => Review[] | Promise<Review[]>;
   }
 }
 

--- a/src/types/query/IReviewQuery.ts
+++ b/src/types/query/IReviewQuery.ts
@@ -1,0 +1,5 @@
+import { QueryResolvers } from '../graphqlgen';
+
+export abstract class IReviewQuery {
+  static getReviews: QueryResolvers.GetReviewsResolver;
+}


### PR DESCRIPTION
#### What does this PR do?
- This PR implements the `getReviews` query resolver.
#### Description of Task to be completed?
- Add getReviews resolver
- Update schema with new resolver
- Update type definitions
- Modify Type resolvers
#### How should this be manually tested?
- Set up the repo locally.
- Create a `getBooks` query
- Add `search`, `limit`, `orderBy`, and `offset` parameters to sort, paginate, and filter as desired
- Observe the result and behaviours.
#### Any background context you want to provide?
#### What are the relevant Github issues?
- [#34](https://github.com/chukwuemekachm/GraphQL-API/issues/34)
#### Screenshots (if appropriate)

<img width="1440" alt="screenshot 2019-01-31 at 1 18 45 pm" src="https://user-images.githubusercontent.com/33798252/52209747-20f1f500-2885-11e9-9509-76a6e7426a11.png">



#### Questions:
- N/A